### PR TITLE
Add in missing properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Features
 
+- Add new Contrast-specific boolean attributes:
+  - `contrastPropagatedContext`: Indicates if a trace has context propagation on root spans
+  - `contrast.protect.event`: Indicates if Contrast Protect detected an attack event
+
 ### Fixes
 
 ## v0.4.0 (2025-02-07)

--- a/docs/general/attributes.md
+++ b/docs/general/attributes.md
@@ -24,6 +24,7 @@ Particular operations may refer to or require some of these attributes.
         * [Client/server example with forward proxy](#clientserver-example-with-forward-proxy)
 - [General remote service attributes](#general-remote-service-attributes)
 - [Source Code Attributes](#source-code-attributes)
+- [Contrast-Specific Attributes](#contrast-specific-attributes)
 
 <!-- tocstop -->
 
@@ -251,4 +252,15 @@ about the span.
 | `code.lineno` | int | The line number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`. | `42` | Recommended |
 | `code.namespace` | string | The "namespace" within which `code.function` is defined. Usually the qualified class or module name, such that `code.namespace` + some separator + `code.function` form a unique identifier for the code unit. | `com.example.MyHttpService` | Recommended |
 | `code.stacktrace` | string | A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG. | `at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)` | Opt-In |
+<!-- endsemconv -->
+
+## Contrast-Specific Attributes
+
+The following attributes are specific to Contrast Security's observability and security monitoring capabilities.
+
+<!-- semconv contrast -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| `contrastPropagatedContext` | boolean | Indicates if a trace has had context propagation provided. This attribute exists on root spans to identify traces with propagated context. | `true`; `false` | Experimental |
+| `contrast.protect.event` | boolean | Indicates if the Contrast Protect agent has detected an attack event on the current resource or span. | `true`; `false` | Experimental |
 <!-- endsemconv -->

--- a/model/general.yaml
+++ b/model/general.yaml
@@ -52,3 +52,27 @@ groups:
       - ref: code.column
       - ref: code.stacktrace
         requirement_level: opt_in
+  - id: contrast.propagation
+    type: span
+    brief: >
+      Contrast-specific attributes for trace context propagation.
+    attributes:
+      - id: contrastPropagatedContext
+        type: boolean
+        stability: experimental
+        brief: >
+          Indicates if a trace has had context propagation provided. This attribute
+          exists on root spans to identify traces with propagated context.
+        examples: [true, false]
+  - id: contrast.protect
+    type: span
+    brief: >
+      Contrast Protect specific attributes for security event detection.
+    attributes:
+      - id: event
+        type: boolean
+        stability: experimental
+        brief: >
+          Indicates if the Contrast Protect agent has detected an attack event
+          on the current resource or span.
+        examples: [true, false]

--- a/schema-next.yaml
+++ b/schema-next.yaml
@@ -2,6 +2,13 @@ file_format: 1.1.0
 schema_url: https://github.com/Contrast-Security-OSS/secobs-semantic-conventions/releases/download/next/next
 versions:
   next:
+    spans:
+      changes:
+        - rename_attributes:
+            attribute_map:
+              # Add new Contrast-specific attributes
+              contrastPropagatedContext: contrastPropagatedContext
+              contrast.protect.event: contrast.protect.event
   0.4.0:
   0.3.0:
   0.2.0:


### PR DESCRIPTION
Fixes #

## Changes

Add new Contrast-specific boolean attributes for trace context propagation and security event detection

Changes Made:
New Attributes Added:

contrastPropagatedContext (boolean) - Indicates if a trace has context propagation provided. This attribute exists on root spans to identify traces with propagated context.
contrast.protect.event (boolean) - Indicates if the Contrast Protect agent has detected an attack event on the current resource or span.

## Merge requirement checklist

- [X] [CONTRIBUTING.md](https://github.com/Contrast-Security-OSS/secobs-semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
- [X] [CHANGELOG.md](https://github.com/Contrast-Security-OSS/secobs-semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
- [X] [schema-next.yaml](https://github.com/Contrast-Security-OSS/secobs-semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
